### PR TITLE
Fix multi-domain allocations

### DIFF
--- a/redhawk/src/control/sdr/dommgr/DomainManager_impl.cpp
+++ b/redhawk/src/control/sdr/dommgr/DomainManager_impl.cpp
@@ -201,7 +201,7 @@ DomainManager_impl::DomainManager_impl (const char* dmdFile, const char* _rootpa
       _eventChannelMgr = new EventChannelManager(this, true, true, true);
       std::string id = _domainName + "/EventChannelManager";
       oid = ossie::corba::activatePersistentObject(poa, _eventChannelMgr, id );
-      _allocationMgr->setLogger(_baseLog->getChildLogger("EventChannelManager", ""));
+      _eventChannelMgr->setLogger(_baseLog->getChildLogger("EventChannelManager", ""));
       _eventChannelMgr->_remove_ref();
       RH_DEBUG(this->_baseLog, "Started EventChannelManager for the domain.");
       // setup IDM and ODM Channels for this domain

--- a/redhawk/src/testing/runtest.props
+++ b/redhawk/src/testing/runtest.props
@@ -22,7 +22,7 @@ log4j.appender.FILE.Threshold=TRACE
 # If you want to debug a specific class, uncomment or add
 # the appropriate line(s) below
 #log4j.logger.prop_utils=TRACE
-#log4j.logger.AllocationManager_impl=TRACE
+#log4j.logger.DomainManager.AllocationManager=TRACE
 #log4j.logger.nodebooter=TRACE
 #log4j.logger.DomainManager_impl=TRACE
 #log4j.logger.ApplicationFactory_impl=TRACE

--- a/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.prf.xml
+++ b/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.prf.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties PUBLIC "-//JTRS//DTD SCA V2.2.2 PRF//EN" "properties.dtd">
+<properties>
+  <simple id="DCE:cdc5ee18-7ceb-4ae6-bf4c-31f983179b4d" mode="readonly" name="device_kind" type="string">
+    <description>This specifies the device kind</description>
+    <kind kindtype="allocation"/>
+    <action type="eq"/>
+  </simple>
+  <simple id="DCE:0f99b2e4-9903-4631-9846-ff349d18ecfb" mode="readonly" name="device_model" type="string">
+    <description> This specifies the specific device</description>
+    <kind kindtype="allocation"/>
+    <action type="eq"/>
+  </simple>
+  <simple id="count" mode="readonly" name="count" type="ulong">
+    <value>1</value>
+    <kind kindtype="property"/>
+    <kind kindtype="allocation"/>
+    <action type="external"/>
+  </simple>
+</properties>

--- a/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.scd.xml
+++ b/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.scd.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE softwarecomponent PUBLIC "-//JTRS//DTD SCA V2.2.2 SCD//EN" "softwarecomponent.dtd">
+<softwarecomponent>
+  <corbaversion>2.2</corbaversion>
+  <componentrepid repid="IDL:CF/Device:1.0"/>
+  <componenttype>device</componenttype>
+  <componentfeatures>
+    <supportsinterface repid="IDL:CF/Device:1.0" supportsname="Device"/>
+    <supportsinterface repid="IDL:CF/Resource:1.0" supportsname="Resource"/>
+    <supportsinterface repid="IDL:CF/LifeCycle:1.0" supportsname="LifeCycle"/>
+    <supportsinterface repid="IDL:CF/TestableObject:1.0" supportsname="TestableObject"/>
+    <supportsinterface repid="IDL:CF/PropertyEmitter:1.0" supportsname="PropertyEmitter"/>
+    <supportsinterface repid="IDL:CF/PropertySet:1.0" supportsname="PropertySet"/>
+    <supportsinterface repid="IDL:CF/PortSet:1.0" supportsname="PortSet"/>
+    <supportsinterface repid="IDL:CF/PortSupplier:1.0" supportsname="PortSupplier"/>
+    <supportsinterface repid="IDL:CF/Logging:1.0" supportsname="Logging"/>
+    <supportsinterface repid="IDL:CF/LogEventConsumer:1.0" supportsname="LogEventConsumer"/>
+    <supportsinterface repid="IDL:CF/LogConfiguration:1.0" supportsname="LogConfiguration"/>
+    <ports/>
+  </componentfeatures>
+  <interfaces>
+    <interface name="Device" repid="IDL:CF/Device:1.0">
+      <inheritsinterface repid="IDL:CF/Resource:1.0"/>
+    </interface>
+    <interface name="Resource" repid="IDL:CF/Resource:1.0">
+      <inheritsinterface repid="IDL:CF/LifeCycle:1.0"/>
+      <inheritsinterface repid="IDL:CF/TestableObject:1.0"/>
+      <inheritsinterface repid="IDL:CF/PropertyEmitter:1.0"/>
+      <inheritsinterface repid="IDL:CF/PortSet:1.0"/>
+      <inheritsinterface repid="IDL:CF/Logging:1.0"/>
+    </interface>
+    <interface name="LifeCycle" repid="IDL:CF/LifeCycle:1.0"/>
+    <interface name="TestableObject" repid="IDL:CF/TestableObject:1.0"/>
+    <interface name="PropertyEmitter" repid="IDL:CF/PropertyEmitter:1.0">
+      <inheritsinterface repid="IDL:CF/PropertySet:1.0"/>
+    </interface>
+    <interface name="PropertySet" repid="IDL:CF/PropertySet:1.0"/>
+    <interface name="PortSet" repid="IDL:CF/PortSet:1.0">
+      <inheritsinterface repid="IDL:CF/PortSupplier:1.0"/>
+    </interface>
+    <interface name="PortSupplier" repid="IDL:CF/PortSupplier:1.0"/>
+    <interface name="Logging" repid="IDL:CF/Logging:1.0">
+      <inheritsinterface repid="IDL:CF/LogEventConsumer:1.0"/>
+      <inheritsinterface repid="IDL:CF/LogConfiguration:1.0"/>
+    </interface>
+    <interface name="LogEventConsumer" repid="IDL:CF/LogEventConsumer:1.0"/>
+    <interface name="LogConfiguration" repid="IDL:CF/LogConfiguration:1.0"/>
+  </interfaces>
+</softwarecomponent>

--- a/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.spd.xml
+++ b/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.spd.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE softpkg PUBLIC "-//JTRS//DTD SCA V2.2.2 SPD//EN" "softpkg.dtd">
+<softpkg id="DCE:c27c79b3-5dd9-47ab-a6d5-f3e251737073" name="AllocatableDevice" type="2.2.1">
+  <title></title>
+  <author>
+    <name>null</name>
+  </author>
+  <propertyfile type="PRF">
+    <localfile name="AllocatableDevice.prf.xml"/>
+  </propertyfile>
+  <descriptor>
+    <localfile name="AllocatableDevice.scd.xml"/>
+  </descriptor>
+  <implementation id="python">
+    <description>The implementation contains descriptive information about the template for a software resource.</description>
+    <code type="Executable">
+      <localfile name="python"/>
+      <entrypoint>python/AllocatableDevice.py</entrypoint>
+    </code>
+    <programminglanguage name="Python"/>
+    <humanlanguage name="EN"/>
+    <runtime name="python" version="2.6.6"/>
+    <os name="Linux"/>
+  </implementation>
+</softpkg>

--- a/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/python/AllocatableDevice.py
+++ b/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/python/AllocatableDevice.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+#
+#
+# AUTO-GENERATED
+#
+# Source: AllocatableDevice.spd.xml
+from ossie.device import start_device
+import logging
+
+from AllocatableDevice_base import *
+
+class AllocatableDevice_i(AllocatableDevice_base):
+    """<DESCRIPTION GOES HERE>"""
+    def constructor(self):
+        """
+        This is called by the framework immediately after your device registers with the system.
+        
+        In general, you should add customization here and not in the __init__ constructor.  If you have 
+        a custom port implementation you can override the specific implementation here with a statement
+        similar to the following:
+          self.some_port = MyPortImplementation()
+
+        """
+        # Save initial "count" value as the max value it can ever have
+        self._maxCount = self.count
+        self.setAllocationImpl("count", self._allocateCount, self._deallocateCount)
+
+    def _allocateCount(self, value):
+        if self.count >= value:
+            self.count -= value
+            return True
+        return False
+
+    def _deallocateCount(self, value):
+        count = self.count + value
+        if count > self._maxCount:
+            self._baseLog.warn("New count %d would exceed max count %d", count, self._maxCount)
+            count = self._maxCount
+        self.count = count
+        
+    def updateUsageState(self):
+        """
+        This is called automatically after allocateCapacity or deallocateCapacity are called.
+        Your implementation should determine the current state of the device:
+           self._usageState = CF.Device.IDLE   # not in use
+           self._usageState = CF.Device.ACTIVE # in use, with capacity remaining for allocation
+           self._usageState = CF.Device.BUSY   # in use, with no capacity remaining for allocation
+        """
+        if self.count == 0:
+            self._usageState = CF.Device.BUSY
+        elif self.count < self._maxCount:
+            self._usageState = CF.Device.ACTIVE
+        else:
+            self._usageState = CF.Device.IDLE
+
+    def process(self):
+        """
+        Basic functionality:
+        
+            The process method should process a single "chunk" of data and then return. This method
+            will be called from the processing thread again, and again, and again until it returns
+            FINISH or stop() is called on the device.  If no work is performed, then return NOOP.
+            
+        StreamSRI:
+            To create a StreamSRI object, use the following code (this generates a normalized SRI that does not flush the queue when full):
+                sri = bulkio.sri.create("my_stream_id")
+
+        PrecisionUTCTime:
+            To create a PrecisionUTCTime object, use the following code:
+                tstamp = bulkio.timestamp.now() 
+  
+        Ports:
+
+            Each port instance is accessed through members of the following form: self.port_<PORT NAME>
+            
+            Data is passed to the serviceFunction through by reading from input streams
+            (BulkIO only). UDP multicast (dataSDDS and dataVITA49) ports do not support
+            streams.
+
+            The input stream from which to read can be requested with the getCurrentStream()
+            method. The optional argument to getCurrentStream() is a floating point number that
+            specifies the time to wait in seconds. A zero value is non-blocking. A negative value
+            is blocking.  Constants have been defined for these values, bulkio.const.BLOCKING and
+            bulkio.const.NON_BLOCKING.
+
+            More advanced uses of input streams are possible; refer to the REDHAWK documentation
+            for more details.
+
+            Input streams return data blocks that include the SRI that was in effect at the time
+            the data was received, and the time stamps associated with that data.
+
+            To send data using a BulkIO interface, create an output stream and write the
+            data to it. When done with the output stream, the close() method sends and end-of-
+            stream flag and cleans up.
+
+            If working with complex data (i.e., the "mode" on the SRI is set to 1),
+            the data block's complex attribute will return True. Data blocks provide a
+            cxdata attribute that gives the data as a list of complex values:
+
+                if block.complex:
+                    outData = [val.conjugate() for val in block.cxdata]
+                    outputStream.write(outData, block.getStartTime())
+
+            Interactions with non-BULKIO ports are left up to the device developer's discretion.
+
+        Messages:
+    
+            To receive a message, you need (1) an input port of type MessageEvent, (2) a message prototype described
+            as a structure property of kind message, (3) a callback to service the message, and (4) to register the callback
+            with the input port.
+        
+            Assuming a property of type message is declared called "my_msg", an input port called "msg_input" is declared of
+            type MessageEvent, create the following code:
+        
+            def msg_callback(self, msg_id, msg_value):
+                print msg_id, msg_value
+        
+            Register the message callback onto the input port with the following form:
+            self.port_input.registerMessage("my_msg", AllocatableDevice_i.MyMsg, self.msg_callback)
+        
+            To send a message, you need to (1) create a message structure, and (2) send the message over the port.
+        
+            Assuming a property of type message is declared called "my_msg", an output port called "msg_output" is declared of
+            type MessageEvent, create the following code:
+        
+            msg_out = AllocatableDevice_i.MyMsg()
+            this.port_msg_output.sendMessage(msg_out)
+
+    Accessing the Application and Domain Manager:
+    
+        Both the Application hosting this Component and the Domain Manager hosting
+        the Application are available to the Component.
+        
+        To access the Domain Manager:
+            dommgr = self.getDomainManager().getRef();
+        To access the Application:
+            app = self.getApplication().getRef();
+        Properties:
+        
+            Properties are accessed directly as member variables. If the property name is baudRate,
+            then accessing it (for reading or writing) is achieved in the following way: self.baudRate.
+
+            To implement a change callback notification for a property, create a callback function with the following form:
+
+            def mycallback(self, id, old_value, new_value):
+                pass
+
+            where id is the property id, old_value is the previous value, and new_value is the updated value.
+            
+            The callback is then registered on the component as:
+            self.addPropertyChangeListener('baudRate', self.mycallback)
+
+        Logging:
+
+            The member _baseLog is a logger whose base name is the component (or device) instance name.
+            New logs should be created based on this logger name.
+
+            To create a new logger,
+                my_logger = self._baseLog.getChildLogger("foo")
+
+            Assuming component instance name abc_1, my_logger will then be created with the 
+            name "abc_1.user.foo".
+            
+        Allocation:
+            
+            Allocation callbacks are available to customize a Device's response to an allocation request. 
+            Callback allocation/deallocation functions are registered using the setAllocationImpl function,
+            usually in the initialize() function
+            For example, allocation property "my_alloc" can be registered with allocation function 
+            my_alloc_fn and deallocation function my_dealloc_fn as follows:
+            
+            self.setAllocationImpl("my_alloc", self.my_alloc_fn, self.my_dealloc_fn)
+            
+            def my_alloc_fn(self, value):
+                # perform logic
+                return True # successful allocation
+            
+            def my_dealloc_fn(self, value):
+                # perform logic
+                pass
+            
+        Example:
+        
+            # This example assumes that the device has two ports:
+            #   - A provides (input) port of type bulkio.InShortPort called dataShort_in
+            #   - A uses (output) port of type bulkio.OutFloatPort called dataFloat_out
+            # The mapping between the port and the class if found in the device
+            # base class.
+            # This example also makes use of the following Properties:
+            #   - A float value called amplitude
+            #   - A boolean called increaseAmplitude
+            
+            inputStream = self.port_dataShort_in.getCurrentStream()
+            if not inputStream:
+                return NOOP
+
+            outputStream = self.port_dataFloat_out.getStream(inputStream.streamID)
+            if not outputStream:
+                outputStream = self.port_dataFloat_out.createStream(inputStream.sri)
+
+            block = inputStream.read()
+            if not block:
+                if inputStream.eos():
+                    outputStream.close()
+                return NOOP
+
+            if self.increaseAmplitude:
+                scale = self.amplitude
+            else:
+                scale = 1.0
+            outData = [float(val) * scale for val in block.data]
+
+            if block.sriChanged:
+                outputStream.sri = block.sri
+
+            outputStream.write(outData, block.getStartTime())
+            return NORMAL
+            
+        """
+        return FINISH
+
+  
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
+    logging.debug("Starting Device")
+    start_device(AllocatableDevice_i)
+

--- a/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/python/AllocatableDevice_base.py
+++ b/redhawk/src/testing/sdr/dev/devices/AllocateBasicDevice_python/AllocatableDevice/python/AllocatableDevice_base.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# AUTO-GENERATED CODE.  DO NOT MODIFY!
+#
+# Source: AllocatableDevice.spd.xml
+from ossie.cf import CF
+from ossie.cf import CF__POA
+from ossie.utils import uuid
+
+from ossie.device import Device
+from ossie.threadedcomponent import *
+from ossie.properties import simple_property
+
+import Queue, copy, time, threading
+
+class AllocatableDevice_base(CF__POA.Device, Device, ThreadedComponent):
+        # These values can be altered in the __init__ of your derived class
+
+        PAUSE = 0.0125 # The amount of time to sleep if process return NOOP
+        TIMEOUT = 5.0 # The amount of time to wait for the process thread to die when stop() is called
+        DEFAULT_QUEUE_SIZE = 100 # The number of BulkIO packets that can be in the queue before pushPacket will block
+
+        def __init__(self, devmgr, uuid, label, softwareProfile, compositeDevice, execparams):
+            Device.__init__(self, devmgr, uuid, label, softwareProfile, compositeDevice, execparams)
+            ThreadedComponent.__init__(self)
+
+            # self.auto_start is deprecated and is only kept for API compatibility
+            # with 1.7.X and 1.8.0 devices.  This variable may be removed
+            # in future releases
+            self.auto_start = False
+            # Instantiate the default implementations for all ports on this device
+
+        def start(self):
+            Device.start(self)
+            ThreadedComponent.startThread(self, pause=self.PAUSE)
+
+        def stop(self):
+            Device.stop(self)
+            if not ThreadedComponent.stopThread(self, self.TIMEOUT):
+                raise CF.Resource.StopError(CF.CF_NOTSET, "Processing thread did not die")
+
+        def releaseObject(self):
+            try:
+                self.stop()
+            except Exception:
+                self._baseLog.exception("Error stopping")
+            Device.releaseObject(self)
+
+        ######################################################################
+        # PORTS
+        # 
+        # DO NOT ADD NEW PORTS HERE.  You can add ports in your derived class, in the SCD xml file, 
+        # or via the IDE.
+
+        ######################################################################
+        # PROPERTIES
+        # 
+        # DO NOT ADD NEW PROPERTIES HERE.  You can add properties in your derived class, in the PRF xml file
+        # or by using the IDE.
+        device_kind = simple_property(id_="DCE:cdc5ee18-7ceb-4ae6-bf4c-31f983179b4d",
+                                      name="device_kind",
+                                      type_="string",
+                                      mode="readonly",
+                                      action="eq",
+                                      kinds=("allocation",),
+                                      description="""This specifies the device kind""")
+
+
+        device_model = simple_property(id_="DCE:0f99b2e4-9903-4631-9846-ff349d18ecfb",
+                                       name="device_model",
+                                       type_="string",
+                                       mode="readonly",
+                                       action="eq",
+                                       kinds=("allocation",),
+                                       description=""" This specifies the specific device""")
+
+
+        count = simple_property(id_="count",
+                                name="count",
+                                type_="ulong",
+                                defvalue=1,
+                                mode="readonly",
+                                action="external",
+                                kinds=("allocation","property"))
+
+
+
+

--- a/redhawk/src/testing/sdr/dev/nodes/MultiDomain1_node/DeviceManager.dcd.xml
+++ b/redhawk/src/testing/sdr/dev/nodes/MultiDomain1_node/DeviceManager.dcd.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE deviceconfiguration PUBLIC "-//JTRS//DTD SCA V2.2.2 DCD//EN" "deviceconfiguration.dtd">
+<deviceconfiguration id="DCE:c28ed3f0-8b99-4c98-9e7b-49a4152de7a1" name="MultiDomain1_node">
+  <devicemanagersoftpkg>
+    <localfile name="/mgr/DeviceManager.spd.xml"/>
+  </devicemanagersoftpkg>
+  <componentfiles>
+    <componentfile id="AllocatableDevice_2fd836ce-e5d3-42ad-857d-27517326c76d" type="SPD">
+      <localfile name="/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.spd.xml"/>
+    </componentfile>
+  </componentfiles>
+  <partitioning>
+    <componentplacement>
+      <componentfileref refid="AllocatableDevice_2fd836ce-e5d3-42ad-857d-27517326c76d"/>
+
+      <componentinstantiation id="MultiDomain1_node:AllocatableDevice_1" startorder="0">
+        <usagename>AllocatableDevice_1</usagename>
+      </componentinstantiation>
+    </componentplacement>
+  </partitioning>
+  <domainmanager>
+    <namingservice name="REDHAWK_DEV/REDHAWK_DEV"/>
+  </domainmanager>
+</deviceconfiguration>

--- a/redhawk/src/testing/sdr/dev/nodes/MultiDomain2_node/DeviceManager.dcd.xml
+++ b/redhawk/src/testing/sdr/dev/nodes/MultiDomain2_node/DeviceManager.dcd.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE deviceconfiguration PUBLIC "-//JTRS//DTD SCA V2.2.2 DCD//EN" "deviceconfiguration.dtd">
+<deviceconfiguration id="DCE:e6e82a49-3c05-4dbf-a8b8-1009c03984e8" name="MultiDomain2_node">
+  <devicemanagersoftpkg>
+    <localfile name="/mgr/DeviceManager.spd.xml"/>
+  </devicemanagersoftpkg>
+  <componentfiles>
+    <componentfile id="AllocatableDevice_0502c154-b532-45e7-8e65-282cc087f72d" type="SPD">
+      <localfile name="/devices/AllocateBasicDevice_python/AllocatableDevice/AllocatableDevice.spd.xml"/>
+    </componentfile>
+  </componentfiles>
+  <partitioning>
+    <componentplacement>
+      <componentfileref refid="AllocatableDevice_0502c154-b532-45e7-8e65-282cc087f72d"/>
+      <componentinstantiation id="MultiDomain2_node:AllocatableDevice_2" startorder="0">
+        <usagename>AllocatableDevice_2</usagename>
+      </componentinstantiation>
+    </componentplacement>
+  </partitioning>
+  <domainmanager>
+    <namingservice name="REDHAWK_DEV/REDHAWK_DEV"/>
+  </domainmanager>
+</deviceconfiguration>

--- a/redhawk/src/testing/sdr/templates/domain/DomainManager2.dmd.xml
+++ b/redhawk/src/testing/sdr/templates/domain/DomainManager2.dmd.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is protected by Copyright. Please refer to the COPYRIGHT file 
+distributed with this source distribution.
+
+This file is part of REDHAWK core.
+
+REDHAWK core is free software: you can redistribute it and/or modify it under 
+the terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation, either version 3 of the License, or (at your option) any 
+later version.
+
+REDHAWK core is distributed in the hope that it will be useful, but WITHOUT ANY 
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
+A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more 
+details.
+
+You should have received a copy of the GNU Lesser General Public License along 
+with this program.  If not, see http://www.gnu.org/licenses/.
+-->
+
+<!DOCTYPE domainmanagerconfiguration SYSTEM "../xml/dtd/domainmanagerconfiguration.dtd">
+<domainmanagerconfiguration id="DCE:925e64d0-8df7-4714-8590-b9a2d557b965" name="DOMAIN_2">
+<description>OSSIE DomainManager Configuration File</description>
+<domainmanagersoftpkg >
+	<localfile name="/mgr/DomainManager.spd.xml"/>
+</domainmanagersoftpkg>
+</domainmanagerconfiguration>


### PR DESCRIPTION
When using the multi-domain allocation feature with more than one request in a single call, the AllocationManager should be able to split the requests across any and all networked domains. However, it is not correctly removing requests that were already fulfilled as it attempts to allocate on the next domain. This ends up over-allocating devices and may cause a failure to deploy an application even though the aggregate set of devices is enough to satisfy the allocation requests.

Scenario:
* _Domain 1_ has one GPP and one FEI device with one tuner (_Device 1_).
* _Domain 2_ has one FEI device with one tuner (_Device 2_).
* _Domain 2_ is registered with _Domain 1_.
* _Domain 1_ tries to launch an application with 2 `usesdevice` elements, each representing an FEI tuner.

The expected sequence of events:
1. _Domain 1_ allocates _Request 1_ on _Device 1_. _Device 1_ is now busy.
2. _Domain 1_ is unable to allocate _Request 2_.
3. _Domain 1_ asks _Domain 2_ to allocate _Request 2_.
4. _Domain 2_ allocates _Request 2_ on _Device 2_.
5. The application deployment succeeds.

Actual sequence of events:
1. _Domain 1_ allocates _Request 1_ on _Device 1_. _Device 1_ is now busy.
2. _Domain 1_ is unable to allocate _Request 2_.
3. _Domain 1_ asks _Domain 2_ to allocate _Request 1_ and _Request 2_. **This is the incorrect behavior**.
4. _Domain 2_ allocates _Request 1_ on _Device 2_. _Device 2_ is now busy.
5. _Domain 2_ is unable to allocate _Request 2_.
6. The application deployment fails.
