### PR TITLE
Fixes to C++ generic IDL port generation

### DIFF
--- a/redhawk-codegen/redhawk/codegen/jinja/cpp/ports/generic.py
+++ b/redhawk-codegen/redhawk/codegen/jinja/cpp/ports/generic.py
@@ -105,6 +105,9 @@ def returnType(typeobj):
     else:
         return name
 
+# Preserve old name in case other places still reference it
+baseReturnType = returnType
+
 def unaliasedType(typeobj):
     kind = typeobj.kind()
     if kind != CORBA.tk_alias:

--- a/redhawk-codegen/redhawk/codegen/jinja/cpp/ports/templates/generic.uses.cpp
+++ b/redhawk-codegen/redhawk/codegen/jinja/cpp/ports/templates/generic.uses.cpp
@@ -32,24 +32,8 @@ ${classname}::~${classname}()
 {
 }
 /*{% for operation in portgen.operations() %}*/
+
 //% set hasreturn = operation.returns != 'void'
-/*{% if hasreturn %}*/
-/*{%     set returnstate='true' %}*/
-/*{% else %}*/
-/*{%     set returnstate='false' %}*/
-/*{% endif %}*/
-//% set hasout = operation.hasout
-/*{% if hasout %}*/
-/*{%     set _hasout='true' %}*/
-/*{% else %}*/
-/*{%     set _hasout='false' %}*/
-/*{% endif %}*/
-//% set hasinout = operation.hasinout
-/*{% if hasinout %}*/
-/*{%     set _hasinout='true' %}*/
-/*{% else %}*/
-/*{%     set _hasinout='false' %}*/
-/*{% endif %}*/
 /*{%  if operation.readwrite_attr %}*/
 ${operation.returns} ${classname}::${operation.name}() {
     return _get_${operation.name}("");
@@ -71,7 +55,7 @@ ${operation.returns} ${classname}::${operation.name}(const std::string __connect
 
     boost::mutex::scoped_lock lock(updatingPortsLock);   // don't want to process while command information is coming in
 
-    __evaluateRequestBasedOnConnections(__connection_id__, ${returnstate}, ${_hasinout}, ${_hasout});
+    __evaluateRequestBasedOnConnections(__connection_id__, ${cpp.boolLiteral(hasreturn)}, ${cpp.boolLiteral(operation.hasinout)}, ${cpp.boolLiteral(operation.hasout)});
     if (this->active) {
         for (i = this->outConnections.begin(); i != this->outConnections.end(); ++i) {
             if (not __connection_id__.empty() and __connection_id__ != (*i).second)

--- a/redhawk-codegen/redhawk/codegen/jinja/cpp/service/mapping.py
+++ b/redhawk-codegen/redhawk/codegen/jinja/cpp/service/mapping.py
@@ -70,12 +70,12 @@ class ServiceMapper(ComponentMapper):
             operations.append({'name': op.name,
                    'arglist': ', '.join('%s %s' % (generic.argumentType(p.paramType,p.direction), p.name) for p in op.params),
                    'argnames': ', '.join(p.name for p in op.params),
-                   'returns': generic.baseReturnType(op.returnType)})
+                   'returns': generic.returnType(op.returnType)})
         for attr in idl.attributes():
             operations.append({'name': attr.name,
                    'arglist': '',
                    'argnames': '',
-                   'returns': generic.baseReturnType(attr.attrType)})
+                   'returns': generic.returnType(attr.attrType)})
             if not attr.readonly:
                 operations.append({'name': attr.name,
                        'arglist': generic.baseType(attr.attrType) + ' data',

--- a/redhawk-codegen/redhawk/codegen/lang/cpp.py
+++ b/redhawk-codegen/redhawk/codegen/lang/cpp.py
@@ -79,6 +79,12 @@ def stringLiteral(string):
 def charLiteral(string):
     return "'" + string + "'"
 
+def boolLiteral(value):
+    if value:
+        return TRUE
+    else:
+        return FALSE
+
 def complexType(typename):
     return 'std::complex<%s>' % (cppType(typename),)
 
@@ -127,10 +133,7 @@ def literal(value, typename, complex=False):
         else:
             return stringLiteral(value)
     elif typename == CorbaTypes.BOOLEAN:
-        if parseBoolean(value):
-            return TRUE
-        else:
-            return FALSE
+        return boolLiteral(parseBoolean(value))
     elif typename in (CorbaTypes.LONGLONG, CorbaTypes.ULONGLONG):
         # Explicitly mark the literal as a 'long long' for 32-bit systems
         if not isinstance(value, list):

--- a/redhawk/src/base/framework/python/ossie/utils/idllib.py
+++ b/redhawk/src/base/framework/python/ossie/utils/idllib.py
@@ -102,7 +102,7 @@ class IDLLibrary(object):
                 self._interfaces[interface.repoId] = interface
 
             # Mark the file that provided this interface as parsed
-            if not isinstance(interface, importIDL.IdlStruct):
+            if isinstance(interface, importIDL.Interface):
                 self._parsed.add(interface.fullpath)
 
         # Mark the file as parsed in case it didn't contain any interfaces

--- a/redhawk/src/base/framework/python/ossie/utils/sca/importIDL.py
+++ b/redhawk/src/base/framework/python/ossie/utils/sca/importIDL.py
@@ -326,6 +326,8 @@ class ExampleVisitor (idlvisitor.AstVisitor):
             node.accept(visitor)
             interface = visitor.interface
             _interfaces[node.repoId()] = interface
+            for decl in node.declarations():
+                decl.accept(self)
         self.myInterfaces.append(interface)
 
 def run(tree, args):

--- a/redhawk/src/base/framework/python/ossie/utils/sca/importIDL.py
+++ b/redhawk/src/base/framework/python/ossie/utils/sca/importIDL.py
@@ -142,12 +142,36 @@ class EnumType(NamedType):
     def enumValues(self):
         return self._enumValues
 
+class Member(object):
+    def __init__(self, name, memberType):
+        self._name = name
+        self._memberType = memberType
+
+    def name(self):
+        return self._name
+
+    def memberType(self):
+        return self._memberType
+
+class Union(NamedType):
+    def __init__(self, scopedName, repoId, discriminant, members):
+        super(Union,self).__init__(CORBA.tk_union, scopedName)
+        self.name = scopedName[-1]
+        self.repoId = repoId
+        self._discriminant = discriminant
+        self._members = members
+
+    def discriminant(self):
+        return self._discriminant
+
+    def members(self):
+        return self._members
+
 def ExceptionType(type):
     return NamedType(CORBA.tk_except, type.scopedName())
 
-# Internal cache of parsed IDL interfaces
-_interfaces = {}
-_structs = {}
+# Internal cache of parsed IDL types
+_cache = {}
 
 class Interface:
     def __init__(self,name,nameSpace="",operations=[],filename="",fullpath="",repoId=""):
@@ -184,7 +208,6 @@ class Interface:
         retstr += "'operations':[" + ','.join(str(op) for op in self.operations) + "]}"
 
         return retstr
-
 
 class Operation:
     def __init__(self,name,returnType,params=[]):
@@ -297,7 +320,7 @@ class IdlStruct():
         for member in node.members():
             name = member.declarators()[0].scopedName()[-1]
             self.members[name] = baseTypes[member.memberType().kind()]
-            self._fields.append((name, IDLType.instance(member.memberType())))
+            self._fields.append(Member(name, IDLType.instance(member.memberType())))
         
 class ExampleVisitor (idlvisitor.AstVisitor):
     def __init__(self,*args):
@@ -315,22 +338,44 @@ class ExampleVisitor (idlvisitor.AstVisitor):
             n.accept(self)
 
     def visitStruct(self, node):
-        # create the Attribute object
-        _struct = IdlStruct(node)
-        _structs[node.repoId()] = _struct
-        self.myStructs.append(_struct)
+        # Use cached post-processed struct if available
+        struct = _cache.get(node.repoId(), None)
+        if not struct:
+            struct = IdlStruct(node)
+            _cache[node.repoId()] = struct
+        self.myStructs.append(struct)
+
+    def visitUnion(self, node):
+        # Use cached post-processed union if available
+        union = _cache.get(node.repoId(), None)
+        if not union:
+            members = []
+            for case in node.cases():
+                name = case.declarator().identifier()
+                idl_type = IDLType.instance(case.caseType())
+                # Ignore case labels here, until there is a need to generate code
+                # based upon them
+                members.append(Member(name, idl_type))
+
+            union = Union(node.scopedName(), node.repoId(), IDLType.instance(node.switchType()), members)
+            _cache[union.repoId] = union
+
+        self.myStructs.append(union)
 
     def visitInterface(self, node):
         # Use cached post-processed interface if available
-        global _interfaces
-        interface = _interfaces.get(node.repoId(), None)
+        interface = _cache.get(node.repoId(), None)
         if not interface:
             visitor = InterfaceVisitor()
             node.accept(visitor)
             interface = visitor.interface
-            _interfaces[node.repoId()] = interface
-            for decl in node.declarations():
-                decl.accept(self)
+            _cache[node.repoId()] = interface
+
+        # Process nested declarations regardless of cache status in case unions
+        # and structs were not requested last time
+        for decl in node.declarations():
+            decl.accept(self)
+
         self.myInterfaces.append(interface)
 
 def run(tree, args):
@@ -382,8 +427,7 @@ def getInterfacesFromFile(filename, includepath=None, getStructs=False):
         x.filename = x.filename[:-4] #remove the .idl suffix
 
     if getStructs:
-        for _struct in structs:
-            ints = ints + structs
+        ints = ints + structs
 
     return ints
 

--- a/redhawk/src/base/framework/python/ossie/utils/sca/importIDL.py
+++ b/redhawk/src/base/framework/python/ossie/utils/sca/importIDL.py
@@ -293,8 +293,11 @@ class IdlStruct():
         self.name = '::'.join(node.scopedName())
         self.repoId = node.repoId()
         self.members = {}
+        self._fields = []
         for member in node.members():
-            self.members[member.declarators()[0].scopedName()[-1]] = baseTypes[member.memberType().kind()]
+            name = member.declarators()[0].scopedName()[-1]
+            self.members[name] = baseTypes[member.memberType().kind()]
+            self._fields.append((name, IDLType.instance(member.memberType())))
         
 class ExampleVisitor (idlvisitor.AstVisitor):
     def __init__(self,*args):

--- a/redhawk/src/testing/tests/idl/TestIdl.idl
+++ b/redhawk/src/testing/tests/idl/TestIdl.idl
@@ -29,4 +29,22 @@ module TestIdl {
 
         NestedStruct func();
     };
+
+    union BasicUnion switch (short) {
+    case 0: octet octetValue;
+    case 1: long longValue;
+    case 2:
+    case 3:
+        float floatValue;
+    default: string stringValue;
+    };
+
+    interface UnionInterface {
+        union NestedUnion switch (long) {
+        case 0: string stringValue;
+        default: any anyValue;
+        };
+
+        NestedUnion func();
+    };
 };

--- a/redhawk/src/testing/tests/idl/TestIdl.idl
+++ b/redhawk/src/testing/tests/idl/TestIdl.idl
@@ -1,0 +1,32 @@
+/*
+ * This file is protected by Copyright. Please refer to the COPYRIGHT file 
+ * distributed with this source distribution.
+ * 
+ * This file is part of REDHAWK core.
+ * 
+ * REDHAWK core is free software: you can redistribute it and/or modify it 
+ * under the terms of the GNU Lesser General Public License as published by the 
+ * Free Software Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ * 
+ * REDHAWK core is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License 
+ * for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License 
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+/**
+ * This module contains IDL constructs for testing the Python IDL library.
+ */
+module TestIdl {
+    interface StructInterface {
+        struct NestedStruct {
+            long field;
+        };
+
+        NestedStruct func();
+    };
+};

--- a/redhawk/src/testing/tests/test_00_PythonUtils.py
+++ b/redhawk/src/testing/tests/test_00_PythonUtils.py
@@ -19,11 +19,14 @@
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 
+import os
 import unittest
 import weakref
 
 from ossie.utils.notify import notification
 from ossie.utils import weakobj
+
+from ossie.utils import idllib
 
 class TestClass(object):
     def foo(self):
@@ -263,3 +266,22 @@ class TestPythonUtils(unittest.TestCase):
 
         del obj3
         self.assertEqual(len(children), 0)
+
+class TestIdlLibrary(unittest.TestCase):
+    def setUp(self):
+        # Use a local IDL library path to have complete control over tests
+        idldir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'idl'))
+        self.lib = idllib.IDLLibrary()
+        self.lib.addSearchPath(idldir)
+
+    def test_NestedStruct(self):
+        """
+        Tests that the IDL library allows looking up structs nested under
+        interfaces.
+        """
+        repo_id = 'IDL:TestIdl/StructInterface/NestedStruct:1.0'
+        try:
+            structdef = self.lib.getIdlStruct(repo_id)
+        except idllib.UnknownInterfaceError as exc:
+            self.fail('Nested IDL struct was not found')
+        self.assertEqual(structdef.repoId, repo_id)

--- a/redhawk/src/testing/tests/test_00_PythonUtils.py
+++ b/redhawk/src/testing/tests/test_00_PythonUtils.py
@@ -285,3 +285,26 @@ class TestIdlLibrary(unittest.TestCase):
         except idllib.UnknownInterfaceError as exc:
             self.fail('Nested IDL struct was not found')
         self.assertEqual(structdef.repoId, repo_id)
+
+    def test_Union(self):
+        repo_id = 'IDL:TestIdl/BasicUnion:1.0'
+        try:
+            union = self.lib.getIdlStruct(repo_id)
+        except idllib.UnknownInterfaceError as exc:
+            self.fail('IDL union was not found')
+        self.assertEqual(union.repoId, repo_id)
+
+        # Make sure it has the exactly the expected members
+        expected = ['octetValue', 'longValue', 'floatValue', 'stringValue']
+        expected.sort()
+        actuals = [m.name() for m in union.members()]
+        actuals.sort()
+        self.assertEqual(expected, actuals)
+
+    def test_NestedUnion(self):
+        repo_id = 'IDL:TestIdl/UnionInterface/NestedUnion:1.0'
+        try:
+            union = self.lib.getIdlStruct(repo_id)
+        except idllib.UnknownInterfaceError as exc:
+            self.fail('Nested IDL union was not found')
+        self.assertEqual(union.repoId, repo_id)


### PR DESCRIPTION
Resolves several issues with custom IDL interfaces and C++ ports:
* Nested structs are resolved (previously caused `redhawk-codegen` to crash).
* Correct determination of fixed-length vs. variable length structs in argument signatures (previously generated code that did not compile).
* Better resolution of `typedef`-ed types.
* Proper handling of union types (same rules as structs).

Testing requires installing custom IDL project to `$OSSIEHOME`. An example IDL project plus test components is attached: [IdlArgs.zip](https://github.com/RedhawkSDR/core-framework/files/3039690/IdlArgs.zip).

