### PR TITLE
Fix for signal 11 on exit of a programmable device

### DIFF
--- a/redhawk-codegen/redhawk/codegen/jinja/cpp/component/programmable/templates/programmable_base.h
+++ b/redhawk-codegen/redhawk/codegen/jinja/cpp/component/programmable/templates/programmable_base.h
@@ -199,11 +199,6 @@ class ${className} : public ${baseClass}
         
 /*{% endif %}*/
         virtual ~${className}() {
-            // Clean up all children that were executed
-            ${executeType.capitalize()}MapIter ${executeType}Iter;
-            for (${executeType}Iter = _${executeType}Map.begin(); ${executeType}Iter != _${executeType}Map.end(); ${executeType}Iter++) {
-                delete ${executeType}Iter->second;
-            }
         }
 
 /*{% if component is device %}*/
@@ -311,6 +306,8 @@ class ${className} : public ${baseClass}
                     ${executeType}Iter->second->setAdminState(CF::Device::UNLOCKED);
 /*{% endif %}*/
                     ${executeType}Iter->second->releaseObject();
+                    ${executeType}Iter->second->_remove_ref();
+                    ${executeType}Iter->second = 0;
                     _processMap.erase(processIter); // Erase process mapping here to minimize collisions with non-persona processIds
                     _${executeType}Map.erase(${executeType}Iter);
                     return;


### PR DESCRIPTION
Upon shutdown of the programmable device with at least one associated persona device, a signal 11 is produced because of a bad clean-up.

The class destructor code actually does nothing since the map gets cleared by terminate's `erase` of everything in the map as the programmable device's `releaseObject()` cleans up its children.  Never the less, `delete` of a Device_impl pointer is bad, rather you should `_remove_ref()`.  However since iterating over the map is doing nothing, we can add the call to `_remove_ref()` after `releaseObject()` in the `terminate()` method, and then set the pointer to 0 to prevent its use in the future (which TBH is _never_ since we're in the `terminate` function, but for the sake of following a best practice pattern, I kept it).